### PR TITLE
Feature: Sharing specific pins via holding a configurable key and middle clicking

### DIFF
--- a/ExploreTogether/ExploreTogether/Patches/Minimap.cs
+++ b/ExploreTogether/ExploreTogether/Patches/Minimap.cs
@@ -133,7 +133,7 @@ namespace ExploreTogether.Patches
                         cartPins.Add(newPin);
                     }
                 }
-                //Debug.Log(cartZDOs.Count + " " + cartPins.Count);
+                Debug.Log(cartZDOs.Count + " " + cartPins.Count);
                 for (int i = 0; i < cartZDOs.Count; i++)
                 {
                     cartPins[i].m_pos = cartZDOs[i].GetPosition();

--- a/ExploreTogether/ExploreTogether/Patches/Minimap.cs
+++ b/ExploreTogether/ExploreTogether/Patches/Minimap.cs
@@ -208,18 +208,21 @@ namespace ExploreTogether.Patches
             Vector3 pos = ScreenToWorldPoint(__instance, Input.mousePosition);
             if (Settings.ShareIndividualPin.Value)
             {
-                if (Enum.TryParse(Settings.ShareIndividualPinKey.Value, out KeyCode key))
+                if (Settings.ShareIndividualPinRequireKey.Value)
                 {
-                    if (Input.GetKey(key))
+                    bool validKey = Enum.TryParse(Settings.ShareIndividualPinKey.Value, out KeyCode key);
+                    if (!validKey || !Input.GetKey(key))
                     {
-                        Minimap.PinData closestPin = GetClosestPin(__instance, pos, ___m_removeRadius * (___m_largeZoom * 2f));
-                        if (closestPin != null)
-                        {
-                            Debug.Log(string.Format("Sharing pin with name: {0}", closestPin.m_name));
-                            Plugin.SendPin(closestPin, closestPin.m_name);
-                            return Settings.ShowPingWhenSharingIndividualPin.Value;
-                        }
+                        return true;
                     }
+                }
+
+                Minimap.PinData closestPin = GetClosestPin(__instance, pos, ___m_removeRadius * (___m_largeZoom * 2f));
+                if (closestPin != null)
+                {
+                    Debug.Log(string.Format("Sharing pin with name: {0}", closestPin.m_name));
+                    Plugin.SendPin(closestPin, closestPin.m_name);
+                    return Settings.ShowPingWhenSharingIndividualPin.Value;
                 }
             }
 

--- a/ExploreTogether/ExploreTogether/Patches/Minimap.cs
+++ b/ExploreTogether/ExploreTogether/Patches/Minimap.cs
@@ -213,9 +213,12 @@ namespace ExploreTogether.Patches
                     if (Input.GetKey(key))
                     {
                         Minimap.PinData closestPin = GetClosestPin(__instance, pos, ___m_removeRadius * (___m_largeZoom * 2f));
-                        Debug.Log(string.Format("Sharing pin with name: {0}", closestPin.m_name));
-                        Plugin.SendPin(closestPin, closestPin.m_name);
-                        return Settings.ShowPingWhenSharingIndividualPin.Value;
+                        if (closestPin != null)
+                        {
+                            Debug.Log(string.Format("Sharing pin with name: {0}", closestPin.m_name));
+                            Plugin.SendPin(closestPin, closestPin.m_name);
+                            return Settings.ShowPingWhenSharingIndividualPin.Value;
+                        }
                     }
                 }
             }

--- a/ExploreTogether/ExploreTogether/Patches/Minimap.cs
+++ b/ExploreTogether/ExploreTogether/Patches/Minimap.cs
@@ -37,6 +37,10 @@ namespace ExploreTogether.Patches
         [HarmonyPatch(typeof(Minimap), "ScreenToWorldPoint", new Type[] { typeof(Vector3) })]
         public static Vector3 ScreenToWorldPoint(object instance, Vector3 screenPos) => throw new NotImplementedException();
 
+        [HarmonyReversePatch]
+        [HarmonyPatch(typeof(Minimap), "GetClosestPin", new Type[] { typeof(Vector3), typeof(float) })]
+        public static Minimap.PinData GetClosestPin(object instance, Vector3 pos, float radius) => throw new NotImplementedException();
+
         [HarmonyPatch(typeof(Minimap), "AddPin")]
         [HarmonyPrefix]
         private static bool Minimap_AddPin(ref Minimap __instance, List<Minimap.PinData> ___m_pins, Vector3 pos, Minimap.PinType type, string name, bool save, bool isChecked)
@@ -129,7 +133,7 @@ namespace ExploreTogether.Patches
                         cartPins.Add(newPin);
                     }
                 }
-                Debug.Log(cartZDOs.Count + " " + cartPins.Count);
+                //Debug.Log(cartZDOs.Count + " " + cartPins.Count);
                 for (int i = 0; i < cartZDOs.Count; i++)
                 {
                     cartPins[i].m_pos = cartZDOs[i].GetPosition();
@@ -193,6 +197,28 @@ namespace ExploreTogether.Patches
                 index = 0;
             else
                 index+=sectorsPerFrame;
+
+            return true;
+        }
+
+
+        [HarmonyPatch(typeof(Minimap), "OnMapMiddleClick", new Type[] {typeof(UIInputHandler)})]
+        [HarmonyPrefix]
+        private static bool Minimap_OnMapMiddleClick(UIInputHandler handler, Minimap __instance, float ___m_removeRadius, float ___m_largeZoom) {
+            Vector3 pos = ScreenToWorldPoint(__instance, Input.mousePosition);
+            if (Settings.ShareIndividualPin.Value)
+            {
+                if (Enum.TryParse(Settings.ShareIndividualPinKey.Value, out KeyCode key))
+                {
+                    if (Input.GetKey(key))
+                    {
+                        Minimap.PinData closestPin = GetClosestPin(__instance, pos, ___m_removeRadius * (___m_largeZoom * 2f));
+                        Debug.Log(string.Format("Sharing pin with name: {0}", closestPin.m_name));
+                        Plugin.SendPin(closestPin, closestPin.m_name);
+                        return Settings.ShowPingWhenSharingIndividualPin.Value;
+                    }
+                }
+            }
 
             return true;
         }

--- a/ExploreTogether/ExploreTogether/Settings.cs
+++ b/ExploreTogether/ExploreTogether/Settings.cs
@@ -19,6 +19,9 @@ namespace ExploreTogether
         public static ConfigEntry<string> PingKey { get; private set; }
         public static ConfigEntry<string> ShareMapKey { get; private set; }
         public static ConfigEntry<string> SharePinsKey { get; private set; }
+        public static ConfigEntry<bool> ShareIndividualPin { get; private set; }
+        public static ConfigEntry<string> ShareIndividualPinKey { get; private set; }
+        public static ConfigEntry<bool> ShowPingWhenSharingIndividualPin { get; private set; }
         public static ConfigEntry<bool> ShareDeathMarkers { get; private set; }
         public static ConfigEntry<bool> PersistentDeathMarkers { get; private set; }
         public static ConfigEntry<float> SharedPinOverlapDistance { get; private set; }
@@ -72,6 +75,21 @@ namespace ExploreTogether
                 "SharePinsKey",
                 "F9",
                 "The keybind to trigger sharing pins with other players");
+
+            ShareIndividualPin = Plugin.Instance.Config.Bind("Minimap",
+                "ShareIndividualPin",
+                true,
+                "Enables the ability to share specific pins by middle clicking while holding a key.");
+
+            ShareIndividualPinKey = Plugin.Instance.Config.Bind("Minimap",
+                "ShareIndividualPinKey",
+                "LeftAlt",
+                "The key that, when held, will allow middle clicking to share individual pins on the map.");
+
+            ShowPingWhenSharingIndividualPin = Plugin.Instance.Config.Bind("Minimap",
+                "ShowPingWhenSharingIndividualPin",
+                true,
+                "Show the map ping when sharing an individual pin.");
 
             ShareDeathMarkers = Plugin.Instance.Config.Bind("Pins",
                 "ShareDeathMarkers",

--- a/ExploreTogether/ExploreTogether/Settings.cs
+++ b/ExploreTogether/ExploreTogether/Settings.cs
@@ -20,6 +20,7 @@ namespace ExploreTogether
         public static ConfigEntry<string> ShareMapKey { get; private set; }
         public static ConfigEntry<string> SharePinsKey { get; private set; }
         public static ConfigEntry<bool> ShareIndividualPin { get; private set; }
+        public static ConfigEntry<bool> ShareIndividualPinRequireKey { get; private set; }
         public static ConfigEntry<string> ShareIndividualPinKey { get; private set; }
         public static ConfigEntry<bool> ShowPingWhenSharingIndividualPin { get; private set; }
         public static ConfigEntry<bool> ShareDeathMarkers { get; private set; }
@@ -80,6 +81,11 @@ namespace ExploreTogether
                 "ShareIndividualPin",
                 true,
                 "Enables the ability to share specific pins by middle clicking while holding a key.");
+
+            ShareIndividualPinRequireKey = Plugin.Instance.Config.Bind("Minimap",
+                "ShareIndividualPinRequireKey",
+                true,
+                "Enables or disables requiring holding a key to share the middle-clicked pin.");
 
             ShareIndividualPinKey = Plugin.Instance.Config.Bind("Minimap",
                 "ShareIndividualPinKey",

--- a/ExploreTogether/README.md
+++ b/ExploreTogether/README.md
@@ -20,6 +20,7 @@ Client side only, no server install required.
 - Pins created by other players will be added to your map *
 - Share your death marker with other players *
 - Tag your death marker with your name and time of death
+- Share specific pins by holding a configurable key and middle clicking pins on the minimap.
 
 #ChangeLog
 ### 1.1.2 - (01/03/2021)


### PR DESCRIPTION
I added functionality to support middle clicking pins (while holding a key) to specifically share that pin (implementing my request #14). 
Options:
* `ShareIndividualPin`: Enables the ability to share specific pins by middle clicking while holding a key. (default: true)
* `ShareIndividualPinKey`: The key that, when held, will allow middle clicking to share individual pins on the map. (default: LeftAlt)
* `ShowPingWhenSharingIndividualPin`: Show the map ping when sharing an individual pin. (default: true)

Edit (as of d3342a8):
* `ShowIndividualPinRequireKey`: Enables or disables requiring holding a key to share the middle-clicked pin. (default true)