### PR TITLE
Gizmo QoL Updates

### DIFF
--- a/Gizmo/Gizmo/Gizmo.csproj
+++ b/Gizmo/Gizmo/Gizmo.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\AppData\Roaming\r2modmanPlus-local\Valheim\profiles\Modded\BepInEx\core\0Harmony.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Valheim\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="assembly_utils">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Valheim\valheim_Data\Managed\assembly_utils.dll</HintPath>
@@ -41,7 +41,7 @@
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Valheim\valheim_Data\Managed\assembly_valheim.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx">
-      <HintPath>..\..\..\..\..\AppData\Roaming\r2modmanPlus-local\Valheim\profiles\Modded\BepInEx\core\BepInEx.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Valheim\BepInEx\core\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -51,17 +51,23 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Valheim\valheim_Data\Managed\UnityEngine.dll</HintPath>
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Valheim\unstripped_managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\..\..\..\..\AppData\Roaming\r2modmanPlus-local\Valheim\profiles\Dev\unstripped_corlib\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Valheim\unstripped_managed\UnityEngine.AssetBundleModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Valheim\valheim_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Valheim\valheim_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+    <Reference Include="UnityEngine.InputLegacyModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Valheim\unstripped_managed\UnityEngine.InputLegacyModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.InputModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Valheim\unstripped_managed\UnityEngine.InputModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
       <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Valheim\valheim_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
@@ -82,4 +88,7 @@
     <EmbeddedResource Include="Resources\gizmos" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)" "C:\Program Files (x86)\Steam\steamapps\common\Valheim\BepInEx\plugins\" /q /y /i</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Gizmo/Gizmo/Plugin.cs
+++ b/Gizmo/Gizmo/Plugin.cs
@@ -129,7 +129,7 @@ namespace Gizmo
             {
                 HandleAxisInput(scrollWheelInput, ref zRot, zGizmo);
             }
-            else if (Player.m_localPlayer.GetRightItem().m_shared.m_name == "$item_hammer")
+            else if (buildMode)
             {
                 HandleAxisInput(scrollWheelInput, ref yRot, yGizmo);
             }

--- a/Gizmo/Gizmo/Plugin.cs
+++ b/Gizmo/Gizmo/Plugin.cs
@@ -14,7 +14,7 @@ using UnityEngine;
 
 namespace Gizmo
 {
-    [BepInPlugin("com.rolopogo.Gizmo","Gizmo", "1.0.0")]
+    [BepInPlugin("com.rolopogo.Gizmo", "Gizmo", "1.0.0")]
     public class Plugin : BaseUnityPlugin
     {
         public static Plugin instance;
@@ -33,10 +33,13 @@ namespace Gizmo
         Transform yGizmoRoot;
         Transform zGizmoRoot;
 
-        private ConfigEntry<int> snapDivisions;
+        public ConfigEntry<int> snapDivisions;
         private ConfigEntry<string> xKey;
         private ConfigEntry<string> zKey;
         private ConfigEntry<string> resetKey;
+        public ConfigEntry<string> cycleSnapKey;
+        public int currentSnapDivisions;
+        public float currentSnapAngle;
 
         float snapAngle => 180f / snapDivisions.Value;
 
@@ -45,7 +48,8 @@ namespace Gizmo
         private void Awake()
         {
             instance = this;
-            snapDivisions = Config.Bind<int>("General", "SnapDivisions", 16, "Number of snap angles per 180 degrees. Vanilla uses 8");
+            snapDivisions = Config.Bind<int>("General", "SnapDivisions", 8, "Number of snap angles per 180 degrees. Vanilla uses 8");
+            cycleSnapKey = Config.Bind<string>("General", "CycleSnapDivisions", "KeypadPlus", "Press this key to cycle between 8, 16 and 32 Snap Divisions");
             xKey = Config.Bind<string>("General", "xKey", "LeftShift", "Hold this key to rotate in the x plane (red circle)");
             zKey = Config.Bind<string>("General", "zKey", "LeftAlt", "Hold this key to rotate in the z plane (blue circle)");
             resetKey = Config.Bind<string>("General", "resetKey", "V", "Press this key to reset the selected axis to zero rotation");
@@ -56,9 +60,13 @@ namespace Gizmo
 
             Harmony.CreateAndPatchAll(typeof(UpdatePlacementGhost_Patch));
             Harmony.CreateAndPatchAll(typeof(UpdatePlacement_Patch));
+
+            currentSnapDivisions = snapDivisions.Value;
+            currentSnapAngle = 180f / currentSnapDivisions;
         }
 
-        public void UpdatePlacement(Player player, GameObject placementGhost, bool takeInput) {
+        public void UpdatePlacement(Player player, GameObject placementGhost, bool takeInput)
+        {
             if (player != Player.m_localPlayer) return;
 
             if (!gizmoRoot)
@@ -67,13 +75,14 @@ namespace Gizmo
                 xGizmo = gizmoRoot.Find("YRoot/ZRoot/XRoot/X");
                 yGizmo = gizmoRoot.Find("YRoot/Y");
                 zGizmo = gizmoRoot.Find("YRoot/ZRoot/Z");
-                xGizmoRoot = gizmoRoot.Find("YRoot/ZRoot/XRoot");
+                xGizmoRoot = gizmoRoot.Find("YRoot/ZRoot/XRoot"); 
                 yGizmoRoot = gizmoRoot.Find("YRoot");
                 zGizmoRoot = gizmoRoot.Find("YRoot/ZRoot");
             }
+
             var marker = player.GetPrivateField<GameObject>("m_placementMarkerInstance");
             if (marker)
-            {   
+            {
                 gizmoRoot.gameObject.SetActive(marker.activeSelf);
                 gizmoRoot.position = marker.transform.position + Vector3.up * .5f;
             }
@@ -84,41 +93,74 @@ namespace Gizmo
             if (!takeInput)
                 return;
 
+            var buildMode = Player.m_localPlayer.GetRightItem().m_shared.m_name == "$item_hammer";
+
             xGizmo.localScale = Vector3.one;
             yGizmo.localScale = Vector3.one;
             zGizmo.localScale = Vector3.one;
 
+            if (Enum.TryParse<KeyCode>(cycleSnapKey.Value, out var cycleSnapKeyCode) && Input.GetKeyUp(cycleSnapKeyCode) && buildMode)
+            {
+                switch (currentSnapDivisions)
+                {
+                    case 8:
+                        currentSnapDivisions = 16;
+                        currentSnapAngle = 180f / currentSnapDivisions;
+                        break;
+                    case 16:
+                        currentSnapDivisions = 32;
+                        currentSnapAngle = 180f / currentSnapDivisions;
+                        break;
+                    case 32:
+                        currentSnapDivisions = 8;
+                        currentSnapAngle = 180f / currentSnapDivisions;
+                        break;
+                }
+                notifyUser("Changed number of snap divisions to " + currentSnapDivisions);
+            }
+
             var scrollWheelInput = Math.Sign(Input.GetAxis("Mouse ScrollWheel"));
 
-            if (Enum.TryParse<KeyCode>(xKey.Value, out var xKeyCode) && Input.GetKey(xKeyCode))
+            if (Enum.TryParse<KeyCode>(xKey.Value, out var xKeyCode) && Input.GetKey(xKeyCode) && buildMode)
             {
                 HandleAxisInput(scrollWheelInput, ref xRot, xGizmo);
             }
-            else if (Enum.TryParse<KeyCode>(zKey.Value, out var zKeyCode) && Input.GetKey(zKeyCode))
+            else if (Enum.TryParse<KeyCode>(zKey.Value, out var zKeyCode) && Input.GetKey(zKeyCode) && buildMode)
             {
                 HandleAxisInput(scrollWheelInput, ref zRot, zGizmo);
             }
-            else
+            else if (Player.m_localPlayer.GetRightItem().m_shared.m_name == "$item_hammer")
             {
                 HandleAxisInput(scrollWheelInput, ref yRot, yGizmo);
             }
 
-            xGizmoRoot.localRotation = Quaternion.Euler(xRot * snapAngle, 0, 0);
-            yGizmoRoot.localRotation = Quaternion.Euler(0, yRot * snapAngle, 0);
-            zGizmoRoot.localRotation = Quaternion.Euler(0, 0, zRot * snapAngle);
+            if (Enum.TryParse<KeyCode>(resetKey.Value, out var resetKeyCode) && Input.GetKeyUp(resetKeyCode) && buildMode)
+            {
+                xRot = 0;
+                yRot = 0;
+                zRot = 0;
+            }
+
+            xGizmoRoot.localRotation = Quaternion.Euler(xRot * currentSnapAngle, 0, 0);
+            yGizmoRoot.localRotation = Quaternion.Euler(0, yRot * currentSnapAngle, 0);
+            zGizmoRoot.localRotation = Quaternion.Euler(0, 0, zRot * currentSnapAngle);
+
         }
 
         private void HandleAxisInput(int scrollWheelInput, ref int rot, Transform gizmo)
         {
             gizmo.localScale = Vector3.one * 1.5f;
-            rot = (rot + scrollWheelInput) % (snapDivisions.Value*2);
-            if (Enum.TryParse<KeyCode>(resetKey.Value, out var resetKeyCode) && Input.GetKey(resetKeyCode))
-                rot = 0;
+            rot = (rot + scrollWheelInput) % (currentSnapDivisions * 2);
         }
 
         private static Quaternion GetPlacementAngle(float x, float y, float z)
         {
             return instance.xGizmoRoot.rotation;
+        }
+
+        private static void notifyUser(string Message, MessageHud.MessageType position = MessageHud.MessageType.TopLeft)
+        {
+            MessageHud.instance.ShowMessage(position, "Gizmo: " + Message);
         }
     }
 }


### PR DESCRIPTION
* Updated gizmo to have universal reset axes key (hitting the key now resets all 3 axes
* Can now manually cycle through 8, 16 and 32 snap divisions (Default is now 8 to start)
* Gizmo now checks if Hammer is currently equipped before doing things